### PR TITLE
Rework Professional Experience, unify section headers, update post-ap…

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,24 @@ My personal portfolio website, showcasing my CV, ongoing projects and a contact 
 
 ## Deployment
 
-### Current (Test)
-
-Used GitHub Pages (`gh-pages` package) to prototype deployments:
+The site is deployed to **GitHub Pages** via the [`gh-pages`](https://www.npmjs.com/package/gh-pages) package — there is no CI workflow. Deploy from your machine with:
 
 ```bash
-npm run build
 npm run deploy
 ```
 
+This runs the `predeploy` script (`npm run build` → outputs to `dist/`) and then pushes the built `dist/` folder to the `gh-pages` branch, which GitHub Pages serves.
+
+- **Live URL:** https://fnnbl.github.io/PortfolioFBL
+- **Base path:** `/PortfolioFBL/` (set as `base` in `vite.config.js`) — required so assets resolve correctly under the project's Pages subpath.
+- **`homepage`** in `package.json` mirrors the live URL.
+
+Notes:
+- Because deploys are pushed manually, remember to run `npm run deploy` after merging changes you want to publish.
+- The `gh-pages` branch is generated output — don't edit it by hand.
+
 ### Future Production
-The site will use a managed host. Changes merged into `main` trigger a CI build (`npm run build`) and auto–deploy to custom domain with SSL/CDN.  
+The site may later move to a managed host, where changes merged into `main` trigger a CI build (`npm run build`) and auto–deploy to a custom domain with SSL/CDN.  
 
 ## Project Structure
 

--- a/src/App.css
+++ b/src/App.css
@@ -90,10 +90,6 @@ p {
   font-weight: 300;
 }
 
-.sectionTitle {
-  margin-bottom: 20px;
-}
-
 .hover {
   cursor: pointer;
 }
@@ -111,9 +107,6 @@ p {
   }
   p {
     font-size: 18px;
-  }
-  .sectionTitle {
-    margin-bottom: 30px;
   }
 }
 
@@ -134,9 +127,6 @@ p {
   p {
     font-size: 20px;
   }
-  .sectionTitle {
-    margin-bottom: 40px;
-  }
 }
 
 @media (min-width: 1400px) {
@@ -145,9 +135,6 @@ p {
   }
   h1 {
     font-size: 48px;
-  }
-  .sectionTitle {
-    margin-bottom: 50px;
   }
 }
 

--- a/src/sections/CVSection/CVSection.jsx
+++ b/src/sections/CVSection/CVSection.jsx
@@ -8,46 +8,81 @@ const CVSection = () => {
 
   const experiences = [
     {
-      period: "September 2023 – Present",
       company: "Phoenix Contact GmbH & Co. KG",
-      role: "Apprenticeship",
-      description: "Computer Science Expert",
+      period: "September 2023 – Present",
+      roles: [
+        {
+          period: "July 2026 – Present",
+          role: "Software Engineering Support Specialist",
+          description:
+            "CI/CD pipelines, SBOMs, developer tooling and integration support for the Signal Conditioner App",
+        },
+        {
+          period: "September 2023 – July 2026",
+          role: "Apprenticeship",
+          description: "Computer Science Expert",
+        },
+      ],
     },
     {
-      period: "October 2020 – August 2023",
       company: "Torwegge GmbH & Co. KG",
-      role: "Logistics Associate",
-      description: "Shipping for the conveyor technology division",
+      period: "October 2020 – August 2023",
+      roles: [
+        {
+          period: "October 2020 – August 2023",
+          role: "Logistics Associate",
+          description: "Shipping for the conveyor technology division",
+        },
+      ],
     },
     {
-      period: "August 2017 – June 2020",
       company: "Dr. August Oetker Nahrungsmittel KG",
-      role: "Apprenticeship",
-      description: "Food Technology Specialist",
+      period: "January 2016 – June 2020",
+      roles: [
+        {
+          period: "August 2017 – June 2020",
+          role: "Apprenticeship",
+          description: "Food Technology Specialist",
+        },
+        {
+          period: "January 2016 – February 2016",
+          role: "Intern",
+          description: "Food Technology Specialist",
+        },
+      ],
     },
     {
-      period: "March 2017 – June 2017",
       company: "Stefan Becker Kunststofftechnik GmbH & Co. KG",
-      role: "Production Associate",
-      description: "Operation of production machinery",
+      period: "March 2017 – June 2017",
+      roles: [
+        {
+          period: "March 2017 – June 2017",
+          role: "Production Associate",
+          description: "Operation of production machinery",
+        },
+      ],
     },
     {
-      period: "August 2016 – January 2017",
       company: "Kreissportbund Lippe e.V.",
-      role: "Federal Volunteer Service",
-      description: "Planning and execution of sports programs for refugees",
+      period: "August 2016 – January 2017",
+      roles: [
+        {
+          period: "August 2016 – January 2017",
+          role: "Federal Volunteer Service",
+          description: "Planning and execution of sports programs for refugees",
+        },
+      ],
     },
     {
-      period: "January 2016 – February 2016",
-      company: "Dr. August Oetker Nahrungsmittel KG",
-      role: "Intern",
-      description: "Food Technology Specialist",
-    },
-    {
-      period: "January 2014",
       company: "Handwerksbildungszentrum Brackwede",
-      role: "Intern",
-      description: "Administrative Assistant",
+      period: "January 2014",
+      roles: [
+        {
+          period: "January 2014",
+          role: "Intern",
+          description: "Administrative Assistant",
+        },
+      ],
     },
   ];
 
@@ -55,14 +90,20 @@ const CVSection = () => {
     <section id="cv" ref={ref} className={`${styles.cvSection} scroll-animate`}>
       <h2 className={styles.title}>Professional Experience</h2>
       <div className={styles.section}>
-        {experiences.map((item, idx) => (
+        {experiences.map((company, idx) => (
           <div key={idx} className={styles.entry}>
-            <div className={styles.entryPeriod}>{item.period}</div>
-            <div className={styles.entryCompany}>{item.company}</div>
-            <div className={styles.entryRole}>{item.role}</div>
-            {item.description && (
-              <div className={styles.entryDesc}>{item.description}</div>
-            )}
+            <div className={styles.entryCompany}>{company.company}</div>
+            <div className={styles.roles}>
+              {company.roles.map((item, rIdx) => (
+                <div key={rIdx} className={styles.role}>
+                  <div className={styles.entryPeriod}>{item.period}</div>
+                  <div className={styles.entryRole}>{item.role}</div>
+                  {item.description && (
+                    <div className={styles.entryDesc}>{item.description}</div>
+                  )}
+                </div>
+              ))}
+            </div>
           </div>
         ))}
       </div>

--- a/src/sections/CVSection/CVSection.module.css
+++ b/src/sections/CVSection/CVSection.module.css
@@ -28,20 +28,53 @@
   margin-bottom: 4rem;
 }
 
+.entry:last-child {
+  margin-bottom: 0;
+}
+
+/* Company name shown once as the group header */
+.entryCompany {
+  font-family: "Roboto Mono", monospace;
+  font-size: 1.3rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 1.25rem;
+}
+
+/* Roles grouped under a company, along a minimal timeline */
+.roles {
+  padding-left: 1.4rem;
+  border-left: 1px solid var(--btn-color);
+}
+
+.role {
+  position: relative;
+  margin-bottom: 2.25rem;
+}
+
+.role:last-child {
+  margin-bottom: 0;
+}
+
+.role::before {
+  content: "";
+  position: absolute;
+  left: calc(-1.4rem - 0.5px);
+  top: 0.45rem;
+  transform: translateX(-50%);
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--btn-color);
+}
+
 .entryPeriod {
   font-family: "Roboto Mono", monospace;
   font-size: 1.25rem;
   font-weight: 600;
   text-transform: uppercase;
   margin-bottom: 0.2rem;
-}
-
-.entryCompany {
-  font-family: "Roboto Mono", monospace;
-  font-size: 1.25rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  margin-bottom: 0.25rem;
 }
 
 .entryRole {
@@ -76,7 +109,6 @@
   opacity: 0.4;
 }
 
-
 @media (max-width: 600px) {
   /* gesamte Section */
   .cvSection {
@@ -95,25 +127,47 @@
     margin-bottom: 50px;
   }
 
-  /* Professional Experience */
+  /* Professional Experience — left-aligned so the timeline reads correctly */
   .entry {
-    margin-bottom: 1.1rem;
+    margin-bottom: 2rem;
     padding: 0 0.4rem;
+    text-align: left;
   }
+
+  .entryCompany {
+    margin-bottom: 0.9rem;
+  }
+
+  .roles {
+    padding-left: 1rem;
+  }
+
+  .role {
+    margin-bottom: 1.4rem;
+  }
+
+  .role::before {
+    left: calc(-1rem - 0.5px);
+    top: 0.3rem;
+    width: 6px;
+    height: 6px;
+  }
+
   .entryPeriod,
   .entryCompany,
   .entryRole {
     font-size: 0.9rem;
     line-height: 1.1;
   }
+
   .entryDesc {
     font-size: 0.7rem;
     line-height: 1.2;
     padding-bottom: 1.5rem;
   }
-  .entryDesc::after {
-    left: 0.4rem;
-    width: calc(100% - 0.8rem);
-  }
 
+  .entryDesc::after {
+    left: 0;
+    width: 100%;
+  }
 }

--- a/src/sections/Contact/Contact.jsx
+++ b/src/sections/Contact/Contact.jsx
@@ -12,7 +12,7 @@ function Contact() {
       ref={ref}
       className={`${styles.container} scroll-animate`}
     >
-      <h1 className="sectionTitle">Contact</h1>
+      <h2 className={styles.title}>Contact</h2>
       <form action="https://formspree.io/f/mwpebwae" method="POST">
         <div className="formGroup">
           <label htmlFor="name" hidden>

--- a/src/sections/Contact/ContactStyles.module.css
+++ b/src/sections/Contact/ContactStyles.module.css
@@ -5,6 +5,21 @@
   margin-top: 90px;
 }
 
+.title {
+  font-family: "Rubik", sans-serif;
+  font-size: 2rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1rem;
+  margin-bottom: 25px;
+}
+
+@media (max-width: 600px) {
+  .title {
+    font-size: 1.5rem;
+    margin-bottom: 15px;
+  }
+}
+
 form {
   display: flex;
   flex-direction: column;

--- a/src/sections/Hero/Hero.jsx
+++ b/src/sections/Hero/Hero.jsx
@@ -41,7 +41,7 @@ function Hero() {
           Blaurock
         </h1>
         <h2 className={styles.subtitle}>
-          Apprentice Computer Science Expert 
+          Software Engineering Support Specialist
           <br />@ Phoenix Contact
         </h2>
         <span>
@@ -62,8 +62,9 @@ function Hero() {
         </span>
         <p className={styles.description}>
           Having gained valuable experience across various roles and industries,
-          I am currently completing my apprenticeship as a computer science
-          expert.
+          I now work as a Software Engineering Support Specialist at Phoenix
+          Contact, following the completion of my apprenticeship as a computer
+          science expert.
         </p>
       </div>
     </section>

--- a/src/sections/Projects/ProjectsStyles.module.css
+++ b/src/sections/Projects/ProjectsStyles.module.css
@@ -9,7 +9,7 @@
   font-size: 2rem;
   text-transform: uppercase;
   letter-spacing: 0.1rem;
-  margin-bottom: 40px;
+  margin-bottom: 25px;
 }
 
 .projectsGrid {
@@ -57,7 +57,7 @@
 
   .projectsSection .title {
     font-size: 1.5rem;
-    margin-bottom: 20px;
+    margin-bottom: 15px;
     text-align: center;
   }
 


### PR DESCRIPTION
…prenticeship content

- CVSection: group experience by company (LinkedIn-style) with a minimal timeline (thin line + small dots) and one company header per employer
- Content: apprenticeship completed (Jul 2026); add current role "Software Engineering Support Specialist @ Phoenix Contact" in Hero + CV
- Consistency: standardize all section titles (Projects margin, Contact header now uses local .title h2), align CV company sub-header typography, remove unused global .sectionTitle class
- README: document the actual gh-pages deploy process